### PR TITLE
orterun.c: re-justify the output message text

### DIFF
--- a/orte/tools/orterun/orterun.c
+++ b/orte/tools/orterun/orterun.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2007-2009 Sun Microsystems, Inc. All rights reserved.
  * Copyright (c) 2007-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved. 
@@ -675,14 +675,14 @@ int orterun(int argc, char *argv[])
     if (0 == geteuid() && !orterun_globals.run_as_root) {
         fprintf(stderr, "--------------------------------------------------------------------------\n");
         if (orterun_globals.help) {
-            fprintf(stderr, "%s cannot provide the help message when run as root\n", orte_basename);
+            fprintf(stderr, "%s cannot provide the help message when run as root.\n", orte_basename);
         } else {
             /* show_help is not yet available, so print an error manually */
             fprintf(stderr, "%s has detected an attempt to run as root.\n", orte_basename);
         }
-        fprintf(stderr, " This is *strongly* discouraged as any mistake (e.g., in defining TMPDIR) or bug can\n");
-        fprintf(stderr, "result in catastrophic damage to the OS file system, leaving\n");
-        fprintf(stderr, "your system in an unusable state.\n\n");
+        fprintf(stderr, "Running at root is *strongly* discouraged as any mistake (e.g., in\n");
+        fprintf(stderr, "defining TMPDIR) or bug can result in catastrophic damage to the OS\n");
+        fprintf(stderr, "file system, leaving your system in an unusable state.\n\n");
         fprintf(stderr, "You can override this protection by adding the --allow-run-as-root\n");
         fprintf(stderr, "option to your cmd line. However, we reiterate our strong advice\n");
         fprintf(stderr, "against doing so - please do so at your own risk.\n");


### PR DESCRIPTION
Rather than keep sniping at open-mpi/ompi-release#220, I figured I'd just give you my own tweaks and see if you're ok with them.  :-)