### PR TITLE
orte proc_info.h: use symbolic names

### DIFF
--- a/orte/util/proc_info.h
+++ b/orte/util/proc_info.h
@@ -61,7 +61,8 @@ typedef uint32_t orte_proc_type_t;
 #define ORTE_PROC_DVM           0x0102   // DVM + daemon
 #define ORTE_PROC_IOF_ENDPT     0x1000
 #define ORTE_PROC_SCHEDULER     0x2000
-#define ORTE_PROC_MASTER        0x4004   // Master + HNP
+#define ORTE_PROC_MASTER_ACTUAL 0x4000
+#define ORTE_PROC_MASTER        (ORTE_PROC_MASTER_ACTUAL + ORTE_PROC_HNP)
 
 #define ORTE_PROC_IS_SINGLETON      (ORTE_PROC_SINGLETON & orte_process_info.proc_type)
 #define ORTE_PROC_IS_DAEMON         (ORTE_PROC_DAEMON & orte_process_info.proc_type)
@@ -75,7 +76,7 @@ typedef uint32_t orte_proc_type_t;
 #define ORTE_PROC_IS_DVM            (ORTE_PROC_DVM & orte_process_info.proc_type)
 #define ORTE_PROC_IS_IOF_ENDPT      (ORTE_PROC_IOF_ENDPT & orte_process_info.proc_type)
 #define ORTE_PROC_IS_SCHEDULER      (ORTE_PROC_SCHEDULER & orte_process_info.proc_type)
-#define ORTE_PROC_IS_MASTER         (0x4000 & orte_process_info.proc_type)
+#define ORTE_PROC_IS_MASTER         (ORTE_PROC_MASTER_ACTUAL & orte_process_info.proc_type)
 
 
 /**


### PR DESCRIPTION
Minor update to open-mpi/ompi-release#747 to use symbolic names.